### PR TITLE
Prepared for use on https://eden-emu.dev/

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta property="og:title" content="Eden - Nintendo Switch Emulator">
     <meta property="og:description" content="Eden is an experimental open-source emulator for the Nintendo Switch, built with performance and stability in mind.">
-    <meta property="og:image" content="https://bixthefin.github.io/fulllogobase.png">
-    <meta property="og:url" content="https://bixthefin.github.io">
+    <meta property="og:image" content="../fulllogobase.png">
+    <meta property="og:url" content="https://eden-emu.dev">
     <meta property="og:type" content="website">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,7 +14,7 @@
 </head>
 <body>
     <header>
-            <div class="logo"><a href="https://bixthefin.github.io"><img src="fulllogobase.png" alt="Eden" width="75" height="75"></a></div>
+            <div class="logo"><a href="../index.html"><img src="fulllogobase.png" alt="Eden" width="75" height="75"></a></div>
                   <nav>
             <a href="pages/blog.html">Blog</a>
             <a href="https://git.eden-emu.dev/eden-emu/eden/releases">Download</a>

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -3,8 +3,8 @@
 <head>
     <meta property="og:title" content="Eden - Blog">
     <meta property="og:description" content="Hear the Latest news about the Eden Project.">
-    <meta property="og:image" content="https://bixthefin.github.io/fulllogobase.png">
-    <meta property="og:url" content="https://bixthefin.github.io">
+    <meta property="og:image" content="../fulllogobase.png">
+    <meta property="og:url" content="https://eden-emu.dev">
     <meta property="og:type" content="website">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,7 +14,7 @@
 <body>
 
 <header>
-        <div class="logo"><a href="https://bixthefin.github.io"><img src="fulllogobase.png" alt="Eden" width="75" height="75"></a></div>
+        <div class="logo"><a href="../index.html"><img src="fulllogobase.png" alt="Eden" width="75" height="75"></a></div>
         <nav>
             <a href="blog.html">Blog</a>
             <a href="https://git.eden-emu.dev/eden-emu/eden/releases">Download</a>

--- a/pages/compatibility.html
+++ b/pages/compatibility.html
@@ -3,8 +3,8 @@
 <head>
     <meta property="og:title" content="Eden - Compatibility">
     <meta property="og:description" content="This shows you what games are compatible with the Eden Emulator.">
-    <meta property="og:image" content="https://bixthefin.github.io/fulllogobase.png">
-    <meta property="og:url" content="https://bixthefin.github.io">
+    <meta property="og:image" content="../fulllogobase.png">
+    <meta property="og:url" content="https://eden-emu.dev">
     <meta property="og:type" content="website">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,7 +14,7 @@
 <body>
 
 <header>
-        <div class="logo"><a href="https://bixthefin.github.io"><img src="fulllogobase.png" alt="Eden" width="75" height="75"></a></div>
+        <div class="logo"><a href="../index.html"><img src="fulllogobase.png" alt="Eden" width="75" height="75"></a></div>
         <nav>
             <a href="blog.html">Blog</a>
             <a href="https://git.eden-emu.dev/eden-emu/eden/releases">Download</a>

--- a/pages/devs.html
+++ b/pages/devs.html
@@ -3,8 +3,8 @@
 <head>
     <meta property="og:title" content="Eden - Developers">
     <meta property="og:description" content="Find out & Support who made this project possible.">
-    <meta property="og:image" content="https://bixthefin.github.io/fulllogobase.png">
-    <meta property="og:url" content="https://bixthefin.github.io">
+    <meta property="og:image" content="../fulllogobase.png">
+    <meta property="og:url" content="https://eden-emu.dev">
     <meta property="og:type" content="website">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="style.css">
     </head>
     <header>
-        <div class="logo"><a href="https://bixthefin.github.io"><img src="fulllogobase.png" alt="Eden" width="75" height="75"></a></div>
+        <div class="logo"><a href="../index.html"><img src="fulllogobase.png" alt="Eden" width="75" height="75"></a></div>
         <nav>
             <a href="blog.html">Blog</a>
             <a href="https://git.eden-emu.dev/eden-emu/eden/releases">Download</a>


### PR DESCRIPTION
This fixed links to work on the new URL and also removed dependence on  on old Github pages URL.