### PR TITLE
redesign: horizon lines fade out

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,5 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4"
-  },
-  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,6 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4"
-  }
+  },
+  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
 }

--- a/src/index.css
+++ b/src/index.css
@@ -599,6 +599,11 @@ a:focus {
     var(--synthwave-blue) 121px,
     transparent 121px
   );
+
+  mask-image: linear-gradient(to bottom, transparent 0%, black 20%, black 90%, transparent 100%);
+  mask-size: 100% 100%;
+  mask-repeat: no-repeat;
+
   transform: perspective(400px) rotateX(75deg);
   transform-origin: bottom;
   opacity: 0.25;


### PR DESCRIPTION
Context: https://old.reddit.com/r/EmulationOnAndroid/comments/1m5c8bb/new_eden_webdesign_feedback_critisism_glazing/n4qus3i/?context=3

Adds a subtle fade-out to the horizon lines so they don't end abruptly.

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/fbc27b8f-1d72-46e6-88dd-a62366705a94) | ![image](https://github.com/user-attachments/assets/8f2625b9-765e-43be-bab8-05f825b13697) |

"Allow edits" is on, if you'd like to tweak the amounts or anything

On an unrelated note, I notice all of the CSS is in a single file (`index.css`), this makes it pretty hard to keep track of what's going on and I would highly recommend splitting the CSS:

`src/components/Example.tsx`
```ts
// ...
import './Example.css'
```
`src/components/Example.css`
```css
.Example {
  width: 420px;
}
```

 