### PR TITLE
redesign: background dim

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -550,6 +550,7 @@ a:focus {
   inset: 0;
   overflow: hidden;
   perspective: 1000px;
+  filter: brightness(0.5);
 }
 
 /* Horizontal synthwave grid lines with glow */


### PR DESCRIPTION
Context: https://old.reddit.com/r/EmulationOnAndroid/comments/1m5c8bb/new_eden_webdesign_feedback_critisism_glazing/n4qus3i/?context=3

Dims the lines in the background, which can make it difficult to read the text that is on top of it. This could be especially troublesome for those with vision difficulties.

| Before| After |
|-|-|
| <img width="1645" height="598" alt="image" src="https://github.com/user-attachments/assets/a421305a-26bb-4900-afcb-cb133aed6497" /> | <img width="1645" height="598" alt="image" src="https://github.com/user-attachments/assets/ec63ed9f-24c8-4fd7-9175-93577c041978" /> |

Using a [contrast checker](https://webaim.org/resources/contrastchecker/) can be pretty helpful in situations like these (though in this case the foreground isn't the WHOLE background, just the lines, but the principle still applies hahaha)

| Before | After |
|-|-|
| <img width="662" height="823" alt="image" src="https://github.com/user-attachments/assets/44884e68-ef06-451c-9ef7-d001160e3c88" /> | <img width="662" height="823" alt="image" src="https://github.com/user-attachments/assets/c7be9e3d-1a88-46c2-b87f-13d7268be8db" /> |

"Allow edits" is on if you'd like to tweak the amount of dimming before merge!